### PR TITLE
Revert "add a section to our README about async/sync style operations"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,6 @@ the Jupyter Software Steering Council.
 
 This repository is **NOT** for opening or discussing JEPs. This can be done in the [dedicated repository](https://github.com/jupyter/enhancement-proposals).
 
-## How the Software Steering Council operates
-
-The Software Steering Council (SSC) is an asynchronous-first council. We do our best not to _require_ synchronous meetings with the whole council since we span various timezones and aim to keep a robust record of all communications. To facilitate this style, we organize our work and track in-flight tasks, using a [Github project board](https://github.com/orgs/jupyter/projects/10/views/1).
-
-That said, we recognize that some "synchronous" time is beneficial to grow our relationships on the council and offer a place for the community to meet the council members.
-
-Thus, we host a weekly, public "office hour" where available SSC members gather to review JEPs, refine process, and triage/organize tasks. No decisions should be made in these meetings; rather, it's a place to meet-and-greet, answer questions, and organize ourselves for the coming week.
-
-Finally ,we use two channels for all of our communication:
-1. For private discussion, we use a google group, jupyter-software-steering-council@googlegroups.com
-2. For public discussion, we use a [team-compass repository](https://github.com/jupyter/software-steering-council-team-compass) on Github.
-
-Anyone is welcome to open an issue or email thread on these two channels to engage the SSC.
 
 ## Code of Conduct
 As an official part of Project Jupyter, all communication across all


### PR DESCRIPTION
This reverts commit 6f955a65a784e2495bdf41710d43e10b2161f265.

I accidentally merged this commit while trying to fix the RTD pages.