### PR TITLE
Add Martha from DEI Working Group and add Carol to emeritus

### DIFF
--- a/docs/council.yaml
+++ b/docs/council.yaml
@@ -13,6 +13,11 @@
   affiliation: QuantStack
   team: active
 
+- name: Martha Cryan
+  handle: "@marthacryan"
+  affiliation: Mito
+  team: active
+
 - name: Itay Dafna
   handle: "@ibdafna"
   affiliation: Netflix
@@ -51,4 +56,9 @@
 - name: Isabela Presedo-Floyd
   handle: "@isabela-pf"
   affiliation: Quansight
+  team: inactive
+
+- name: Carol Willing
+  handle: "@willingc"
+  affiliation: Willing Consulting
   team: inactive


### PR DESCRIPTION
Welcome @marthacryan to the SSC (representing the DEI Working Group)! 🎉 

Great to have you here! 

This PR also adds @willingc to our SSC Emeritus section (recently added in the last PR). Carol, massive apologies that we didn't have this page before or add you when we merged it! ❤️