### PR TITLE
Update SSC membership

### DIFF
--- a/docs/council.yaml
+++ b/docs/council.yaml
@@ -10,7 +10,6 @@
 
 - name: Paul Ivanov
   handle: "@ivanov"
-  affiliation: Noteable
   team: active
 
 - name: Johan Mabille
@@ -33,11 +32,6 @@
   affiliation: QuantStack
   team: active
 
-- name: Zach Sailer
-  handle: "@Zsailer"
-  affiliation: Apple
-  team: active
-
 - name: Jeremy Tuloup
   handle: "@jtpio"
   affiliation: QuantStack
@@ -48,27 +42,26 @@
   affiliation: UC San Diego
   team: active
 
+- name: Zach Sailer
+  handle: "@Zsailer"
+  team: inactive
+
 - name: Eric Charles
   handle: "@echarles"
-  affiliation: Datalayer
   team: inactive
 
 - name: Frédéric Collonval
   handle: "@fcollonval"
-  affiliation: QuantStack
   team: inactive
 
 - name: Itay Dafna
   handle: "@ibdafna"
-  affiliation: Netflix
   team: inactive
 
 - name: Isabela Presedo-Floyd
   handle: "@isabela-pf"
-  affiliation: Quansight
   team: inactive
 
 - name: Carol Willing
   handle: "@willingc"
-  affiliation: Willing Consulting
   team: inactive


### PR DESCRIPTION
This was flagged during the SSC working call.

This PR does three things:

 - It removes Zach Sailer from the active list of members of the SSC since he was elected to the EC. Ping @Zsailer.
 - It removes affiliations of former members of the SSC. At least two of these did not seem up to date, and the list is only going to grow. It seemed a good idea to people on the call to only keep track of affiliations of current members.
 - It removes the outdated affiliation of Paul Ivanov @ivanov - consistently with the Jupyter website.

This should now reflect the same state as the Jupyter website.